### PR TITLE
fix: override retry config, enforce large retry times, and fix min gas amount

### DIFF
--- a/bbnrelayer/utils.go
+++ b/bbnrelayer/utils.go
@@ -152,6 +152,7 @@ func (r *Relayer) waitUntilQuerable(
 		}
 		// in case block at srch/dsth has not been committed yet
 		// see https://github.com/tendermint/tendermint/issues/7641
+		// TODO: remove below after bumping Tendermint to versions after https://github.com/tendermint/tendermint/pull/7642
 		srch--
 		dsth--
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/babylonchain/babylon-relayer/bbnrelayer"
 	"github.com/babylonchain/babylon-relayer/config"
 	relaydebug "github.com/babylonchain/babylon-relayer/debug"
@@ -56,10 +57,13 @@ func keepUpdatingClientsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// override retry in relayer config
 			numRetries, err := cmd.Flags().GetUint("retry")
 			if err != nil {
 				return err
 			}
+			relayer.RtyAttNum = numRetries
+			relayer.RtyDel = retry.Delay(time.Second)
 
 			// initialise prometheus registry
 			metrics := relaydebug.NewPrometheusMetrics()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -63,6 +63,7 @@ func keepUpdatingClientsCmd() *cobra.Command {
 				return err
 			}
 			relayer.RtyAttNum = numRetries
+			relayer.RtyAtt = retry.Attempts(relayer.RtyAttNum)
 			relayer.RtyDel = retry.Delay(time.Second)
 
 			// initialise prometheus registry
@@ -100,7 +101,7 @@ func keepUpdatingClientsCmd() *cobra.Command {
 
 	cmd.Flags().String("memo", "", "a memo to include in relayed packets")
 	cmd.Flags().Duration("interval", time.Minute*10, "the interval between two update-client attempts")
-	cmd.Flags().Uint("retry", relayer.RtyAttNum, "number of retry attempts for requests")
+	cmd.Flags().Uint("retry", 20, "number of retry attempts for requests")
 	cmd.Flags().String("debug-addr", "", "address for the debug server with Prometheus metrics")
 
 	return cmd

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -14,7 +14,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 1uakt
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json
@@ -30,7 +30,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 0.002ubbn
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json
@@ -46,7 +46,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 50000000000inj
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json
@@ -63,7 +63,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 0.1ujunox
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json
@@ -79,7 +79,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 0.01uosmo
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json
@@ -95,7 +95,7 @@ chains:
             keyring-backend: test
             gas-adjustment: 1.5
             gas-prices: 0.1uscrt
-            min-gas-amount: 0
+            min-gas-amount: 1
             debug: true
             timeout: 10s
             output-format: json


### PR DESCRIPTION
This PR fixes a number of issues reported during merging relayer to infra.
Specifically, this PR

1. overrides retry config in the relayer dependency, such that all called functions in the relayer dependency apply our relayer config
2. increases the retry time to 20 by default, and increases the retry interval to 1 second from 0.4 second
3. sets `min-gas-amount: 1` in example config

Rationale:
- 12 aims at fixing the `height requested is too high` issue. The reason is that `QueryLatestHeights` returns the latest height that may not be committed yet. This makes any ABCI query with this height fails due to `height requested is too high` error. This is an known issue https://github.com/tendermint/tendermint/issues/7641 and is fixed by a later PR to Tendermint. All we can do before bumping Tendermint is to retry more until the chain grows beyond that height.
- 3 aims at fixing the `Error building or broadcasting transaction` issue. The reason is as described [here](https://github.com/cosmos/relayer/blob/main/docs/troubleshooting.md#inspect-go-runtime-debug-data).

