### PR TITLE
fix: fix retries and metrics

### DIFF
--- a/bbnrelayer/client.go
+++ b/bbnrelayer/client.go
@@ -49,7 +49,16 @@ func (r *Relayer) UpdateClient(
 			return fmt.Errorf("failed to query latest heights: %w", err)
 		}
 		return nil
-	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr); err != nil {
+	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
+		r.logger.Info(
+			"Failed to query latest heights",
+			zap.String("src_chain_id", src.ChainID()),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.Uint("attempt", n+1),
+			zap.Uint("max_attempts", numRetries),
+			zap.Error(err),
+		)
+	})); err != nil {
 		return err
 	}
 

--- a/bbnrelayer/client.go
+++ b/bbnrelayer/client.go
@@ -128,8 +128,6 @@ func (r *Relayer) KeepUpdatingClient(
 
 	ticker := time.NewTicker(interval)
 	for ; true; <-ticker.C {
-		r.metrics.RelayedHeadersCounter.WithLabelValues(src.ChainID(), dst.ChainID()).Inc()
-
 		// Note that UpdateClient is a thread-safe function
 		if err := r.UpdateClient(ctx, src, dst, numRetries); err != nil {
 			r.logger.Error(
@@ -146,6 +144,8 @@ func (r *Relayer) KeepUpdatingClient(
 			// the endpoint of dst chain is temporarily unavailable
 			// TODO: distinguish unrecoverable errors
 		}
+
+		r.metrics.RelayedHeadersCounter.WithLabelValues(src.ChainID(), dst.ChainID()).Inc()
 	}
 	return nil
 }

--- a/bbnrelayer/client.go
+++ b/bbnrelayer/client.go
@@ -152,9 +152,9 @@ func (r *Relayer) KeepUpdatingClient(
 			// NOTE: the for loop continues here since it's possible that
 			// the endpoint of dst chain is temporarily unavailable
 			// TODO: distinguish unrecoverable errors
+		} else {
+			r.metrics.RelayedHeadersCounter.WithLabelValues(src.ChainID(), dst.ChainID()).Inc()
 		}
-
-		r.metrics.RelayedHeadersCounter.WithLabelValues(src.ChainID(), dst.ChainID()).Inc()
 	}
 	return nil
 }

--- a/bbnrelayer/utils.go
+++ b/bbnrelayer/utils.go
@@ -42,7 +42,16 @@ func (r *Relayer) createClientIfNotExist(
 			return fmt.Errorf("failed to query latest heights: %w", err)
 		}
 		return nil
-	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr); err != nil {
+	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
+		r.logger.Info(
+			"Failed to query latest heights",
+			zap.String("src_chain_id", src.ChainID()),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.Uint("attempt", n+1),
+			zap.Uint("max_attempts", numRetries),
+			zap.Error(err),
+		)
+	})); err != nil {
 		return err
 	}
 	// in case block at srch/dsth has not been committed yet
@@ -82,7 +91,16 @@ func (r *Relayer) createClientIfNotExist(
 			return fmt.Errorf("failed to query update headers: %w", err)
 		}
 		return nil
-	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr); err != nil {
+	}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
+		r.logger.Info(
+			"Failed to query update headers",
+			zap.String("src_chain_id", src.ChainID()),
+			zap.String("dst_chain_id", dst.ChainID()),
+			zap.Uint("attempt", n+1),
+			zap.Uint("max_attempts", numRetries),
+			zap.Error(err),
+		)
+	})); err != nil {
 		return err
 	}
 
@@ -175,7 +193,16 @@ func (r *Relayer) waitUntilQuerable(
 				return fmt.Errorf("failed to query latest heights: %w", err)
 			}
 			return nil
-		}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr); err != nil {
+		}, retry.Context(ctx), retry.Attempts(numRetries), relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
+			r.logger.Info(
+				"Failed to query latest heights",
+				zap.String("src_chain_id", src.ChainID()),
+				zap.String("dst_chain_id", dst.ChainID()),
+				zap.Uint("attempt", n+1),
+				zap.Uint("max_attempts", numRetries),
+				zap.Error(err),
+			)
+		})); err != nil {
 			return err
 		}
 		// in case block at srch/dsth has not been committed yet

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -96,7 +96,7 @@ func keepUpdatingClientsCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Duration("interval", time.Minute*10, "the interval between two update-client attempts")
-	cmd.Flags().Uint("retry", 20, "number of retry attempts for requests")
+	cmd.Flags().Uint("retry", 5, "number of retry attempts for requests")
 	cmd.Flags().String("debug-addr", "", "address for the debug server with Prometheus metrics")
 
 	return cmd

--- a/cmd/update-client.go
+++ b/cmd/update-client.go
@@ -133,7 +133,7 @@ corresponding update-client message to babylon_chain_name.`,
 	}
 
 	cmd.Flags().Duration("interval", time.Minute*10, "the interval between two update-client attempts")
-	cmd.Flags().Uint("retry", 20, "number of retry attempts for requests")
+	cmd.Flags().Uint("retry", 5, "number of retry attempts for requests")
 	cmd.Flags().String("debug-addr", "", "address for the debug server with Prometheus metrics")
 
 	return cmd


### PR DESCRIPTION
Fixes [BM-552](https://babylon-chain.atlassian.net/browse/BM-552)
Context: https://github.com/babylonchain/infra/pull/73 and some offline dicussions

This PR fixes the issue that `cosmos_relayer_failed_headers` never occurs. It seems to be because the default number of retries in the code is too big. During the retry process, no log is produced. This PR reduces the default value to 5, and produces logs when each retry attempt fails. It also fixes a minor bug that the `RelayedHeadersCounter` increases even if the header is relayed successfully.

Tested locally and I can see the `cosmos_relayer_failed_headers` metrics is increasing correctly for the Injective node that is unreachable.

![image](https://user-images.githubusercontent.com/9570153/222039351-fd6138f2-18f7-41de-bfcf-b76c8c38787e.png)

Also each retry attempt now produces logs.

![image](https://user-images.githubusercontent.com/9570153/222040920-0ef8d576-42e7-4deb-8933-3318e5f9f52c.png)
